### PR TITLE
return result outside CHECK macro in ibvwrap.cc

### DIFF
--- a/src/debug.cc
+++ b/src/debug.cc
@@ -26,6 +26,20 @@ void ncclDebugInit() {
   pthread_mutex_lock(&ncclDebugLock);
   if (ncclDebugLevel != -1) { pthread_mutex_unlock(&ncclDebugLock); return; }
   const char* nccl_debug = getenv("NCCL_DEBUG");
+  int tempNcclDebugLevel = -1;
+  if (nccl_debug == NULL) {
+    tempNcclDebugLevel = NCCL_LOG_NONE;
+  } else if (strcasecmp(nccl_debug, "VERSION") == 0) {
+    tempNcclDebugLevel = NCCL_LOG_VERSION;
+  } else if (strcasecmp(nccl_debug, "WARN") == 0) {
+    tempNcclDebugLevel = NCCL_LOG_WARN;
+  } else if (strcasecmp(nccl_debug, "INFO") == 0) {
+    tempNcclDebugLevel = NCCL_LOG_INFO;
+  } else if (strcasecmp(nccl_debug, "ABORT") == 0) {
+    tempNcclDebugLevel = NCCL_LOG_ABORT;
+  } else if (strcasecmp(nccl_debug, "TRACE") == 0) {
+    tempNcclDebugLevel = NCCL_LOG_TRACE;
+  }
 
   /* Parse the NCCL_DEBUG_SUBSYS env var
    * This can be a comma separated list such as INIT,COLL
@@ -80,7 +94,7 @@ void ncclDebugInit() {
    * NCCL_DEBUG level is > VERSION
    */
   const char* ncclDebugFileEnv = getenv("NCCL_DEBUG_FILE");
-  if (ncclDebugLevel > NCCL_LOG_VERSION && ncclDebugFileEnv != NULL) {
+  if (tempNcclDebugLevel > NCCL_LOG_VERSION && ncclDebugFileEnv != NULL) {
     int c = 0;
     char debugFn[PATH_MAX+1] = "";
     char *dfn = debugFn;
@@ -113,21 +127,6 @@ void ncclDebugInit() {
         ncclDebugFile = file;
       }
     }
-  }
-
-  int tempNcclDebugLevel = -1;
-  if (nccl_debug == NULL) {
-    tempNcclDebugLevel = NCCL_LOG_NONE;
-  } else if (strcasecmp(nccl_debug, "VERSION") == 0) {
-    tempNcclDebugLevel = NCCL_LOG_VERSION;
-  } else if (strcasecmp(nccl_debug, "WARN") == 0) {
-    tempNcclDebugLevel = NCCL_LOG_WARN;
-  } else if (strcasecmp(nccl_debug, "INFO") == 0) {
-    tempNcclDebugLevel = NCCL_LOG_INFO;
-  } else if (strcasecmp(nccl_debug, "ABORT") == 0) {
-    tempNcclDebugLevel = NCCL_LOG_ABORT;
-  } else if (strcasecmp(nccl_debug, "TRACE") == 0) {
-    tempNcclDebugLevel = NCCL_LOG_TRACE;
   }
 
   ncclEpoch = std::chrono::steady_clock::now();

--- a/src/misc/ibvwrap.cc
+++ b/src/misc/ibvwrap.cc
@@ -145,64 +145,71 @@ teardown:
   return ncclSystemError;
 }
 
-#define IBV_PTR_CHECK_ERRNO(name_internal, call, retval, error_retval, name) \
+#define IBV_PTR_CHECK_ERRNO_NO_RETURN(name_internal, call, retval, error_retval, name, res) \
+  res = ncclSuccess; \
   if (name_internal == NULL) { \
-     WARN("lib wrapper not initialized."); \
-     return ncclInternalError; \
-  } \
-  retval = call; \
-  if (retval == error_retval) { \
-    WARN("Call to " name " failed with error %s", strerror(errno)); \
-    return ncclSystemError; \
-  } \
-  return ncclSuccess;
+    WARN("lib wrapper not initialized."); \
+    res = ncclInternalError; \
+  } else { \
+    retval = call; \
+    if (retval == error_retval) { \
+      WARN("Call to " name " failed with error %s", strerror(errno)); \
+      res = ncclSystemError; \
+    } \
+  }
 
-#define IBV_PTR_CHECK(name_internal, call, retval, error_retval, name) \
+#define IBV_PTR_CHECK_NO_RETURN(name_internal, call, retval, error_retval, name, res) \
+  res = ncclSuccess; \
   if (name_internal == NULL) { \
      WARN("lib wrapper not initialized."); \
-     return ncclInternalError; \
-  } \
-  retval = call; \
-  if (retval == error_retval) { \
-    WARN("Call to " name " failed"); \
-    return ncclSystemError; \
-  } \
-  return ncclSuccess;
+     res = ncclInternalError; \
+  } else { \
+     retval = call; \
+     if (retval == error_retval) { \
+       WARN("Call to " name " failed"); \
+       res = ncclSystemError; \
+     } \
+  }
 
-#define IBV_INT_CHECK_RET_ERRNO(name_internal, call, success_retval, name) \
+#define IBV_INT_CHECK_RET_ERRNO_NO_RETURN(name_internal, call, success_retval, name, res) \
+  res = ncclSuccess; \
   if (name_internal == NULL) { \
      WARN("lib wrapper not initialized."); \
-     return ncclInternalError; \
-  } \
-  int ret = call; \
-  if (ret != success_retval) { \
-    WARN("Call to " name " failed with error %s", strerror(ret)); \
-    return ncclSystemError; \
-  } \
-  return ncclSuccess;
+     res = ncclInternalError; \
+  } else { \
+     int ret = call; \
+     if (ret != success_retval) { \
+       WARN("Call to " name " failed with error %s", strerror(ret)); \
+       res = ncclSystemError; \
+     } \
+  }
 
-#define IBV_INT_CHECK(name_internal, call, error_retval, name) \
+#define IBV_INT_CHECK_NO_RETURN(name_internal, call, error_retval, name, res) \
+  res = ncclSuccess; \
   if (name_internal == NULL) { \
      WARN("lib wrapper not initialized."); \
-     return ncclInternalError; \
-  } \
-  int ret = call; \
-  if (ret == error_retval) { \
-    WARN("Call to " name " failed"); \
-    return ncclSystemError; \
-  } \
-  return ncclSuccess;
+     res = ncclInternalError; \
+  } else { \
+     int ret = call; \
+     if (ret == error_retval) { \
+       WARN("Call to " name " failed"); \
+       res = ncclSystemError; \
+     } \
+  }
 
-#define IBV_PASSTHRU(name_internal, call) \
+#define IBV_PASSTHRU_NO_RETURN(name_internal, call, res) \
+  res = ncclSuccess; \
   if (name_internal == NULL) { \
      WARN("lib wrapper not initialized."); \
-     return ncclInternalError; \
-  } \
-  call; \
-  return ncclSuccess;
+     res = ncclInternalError; \
+  } else { \
+     call; \
+  }
 
 ncclResult_t wrap_ibv_fork_init() {
-  IBV_INT_CHECK(ibv_internal_fork_init, ibv_internal_fork_init(), -1, "ibv_fork_init");
+  ncclResult_t res;
+  IBV_INT_CHECK_NO_RETURN(ibv_internal_fork_init, ibv_internal_fork_init(), -1, "ibv_fork_init", res);
+  return res;
 }
 
 ncclResult_t wrap_ibv_get_device_list(struct ibv_device ***ret, int *num_devices) {
@@ -212,7 +219,9 @@ ncclResult_t wrap_ibv_get_device_list(struct ibv_device ***ret, int *num_devices
 }
 
 ncclResult_t wrap_ibv_free_device_list(struct ibv_device **list) {
-  IBV_PASSTHRU(ibv_internal_free_device_list, ibv_internal_free_device_list(list));
+  ncclResult_t res;
+  IBV_PASSTHRU_NO_RETURN(ibv_internal_free_device_list, ibv_internal_free_device_list(list), res);
+  return res;
 }
 
 const char *wrap_ibv_get_device_name(struct ibv_device *device) {
@@ -224,47 +233,69 @@ const char *wrap_ibv_get_device_name(struct ibv_device *device) {
 }
 
 ncclResult_t wrap_ibv_open_device(struct ibv_context **ret, struct ibv_device *device) { /*returns 0 on success, -1 on failure*/
-  IBV_PTR_CHECK(ibv_internal_open_device, ibv_internal_open_device(device), *ret, NULL, "ibv_open_device");
+  ncclResult_t res;
+  IBV_PTR_CHECK_NO_RETURN(ibv_internal_open_device, ibv_internal_open_device(device), *ret, NULL, "ibv_open_device", res);
+  return res;
 }
 
 ncclResult_t wrap_ibv_close_device(struct ibv_context *context) { /*returns 0 on success, -1 on failure*/
-  IBV_INT_CHECK(ibv_internal_close_device, ibv_internal_close_device(context), -1, "ibv_close_device");
+  ncclResult_t res;
+  IBV_INT_CHECK_NO_RETURN(ibv_internal_close_device, ibv_internal_close_device(context), -1, "ibv_close_device", res);
+  return res;
 }
 
 ncclResult_t wrap_ibv_get_async_event(struct ibv_context *context, struct ibv_async_event *event) { /*returns 0 on success, and -1 on error*/
-  IBV_INT_CHECK(ibv_internal_get_async_event, ibv_internal_get_async_event(context, event), -1, "ibv_get_async_event");
+  ncclResult_t res;
+  IBV_INT_CHECK_NO_RETURN(ibv_internal_get_async_event, ibv_internal_get_async_event(context, event), -1, "ibv_get_async_event", res);
+  return res;
 }
 
 ncclResult_t wrap_ibv_ack_async_event(struct ibv_async_event *event) {
-  IBV_PASSTHRU(ibv_internal_ack_async_event, ibv_internal_ack_async_event(event));
+  ncclResult_t res;
+  IBV_PASSTHRU_NO_RETURN(ibv_internal_ack_async_event, ibv_internal_ack_async_event(event), res);
+  return res;
 }
 
 ncclResult_t wrap_ibv_query_device(struct ibv_context *context, struct ibv_device_attr *device_attr) { /*returns 0 on success, or the value of errno on failure (which indicates the failure reason)*/
-  IBV_INT_CHECK_RET_ERRNO(ibv_internal_query_device, ibv_internal_query_device(context, device_attr), 0, "ibv_query_device");
+  ncclResult_t res;
+  IBV_INT_CHECK_RET_ERRNO_NO_RETURN(ibv_internal_query_device, ibv_internal_query_device(context, device_attr), 0, "ibv_query_device", res);
+  return res;
 }
 
 ncclResult_t wrap_ibv_query_port(struct ibv_context *context, uint8_t port_num, struct ibv_port_attr *port_attr) { /*returns 0 on success, or the value of errno on failure (which indicates the failure reason)*/
-  IBV_INT_CHECK_RET_ERRNO(ibv_internal_query_port, ibv_internal_query_port(context, port_num, port_attr), 0, "ibv_query_port");
+  ncclResult_t res;
+  IBV_INT_CHECK_RET_ERRNO_NO_RETURN(ibv_internal_query_port, ibv_internal_query_port(context, port_num, port_attr), 0, "ibv_query_port", res);
+  return res;
 }
 
 ncclResult_t wrap_ibv_query_gid(struct ibv_context *context, uint8_t port_num, int index, union ibv_gid *gid) {
-  IBV_INT_CHECK_RET_ERRNO(ibv_internal_query_gid, ibv_internal_query_gid(context, port_num, index, gid), 0, "ibv_query_gid");
+   ncclResult_t res;
+   IBV_INT_CHECK_RET_ERRNO_NO_RETURN(ibv_internal_query_gid, ibv_internal_query_gid(context, port_num, index, gid), 0, "ibv_query_gid", res);
+   return res;
 }
 
 ncclResult_t wrap_ibv_query_qp(struct ibv_qp *qp, struct ibv_qp_attr *attr, int attr_mask, struct ibv_qp_init_attr *init_attr) {
-  IBV_INT_CHECK_RET_ERRNO(ibv_internal_query_qp, ibv_internal_query_qp(qp, attr, attr_mask, init_attr), 0, "ibv_query_qp");
+  ncclResult_t res;
+  IBV_INT_CHECK_RET_ERRNO_NO_RETURN(ibv_internal_query_qp, ibv_internal_query_qp(qp, attr, attr_mask, init_attr), 0, "ibv_query_qp", res);
+  return res;
 }
 
 ncclResult_t wrap_ibv_alloc_pd(struct ibv_pd **ret, struct ibv_context *context) {
-  IBV_PTR_CHECK(ibv_internal_alloc_pd, ibv_internal_alloc_pd(context), *ret, NULL, "ibv_alloc_pd");
+  ncclResult_t res;
+  IBV_PTR_CHECK_NO_RETURN(ibv_internal_alloc_pd, ibv_internal_alloc_pd(context), *ret, NULL, "ibv_alloc_pd", res);
+  return res;
 }
 
 ncclResult_t wrap_ibv_dealloc_pd(struct ibv_pd *pd) { /*returns 0 on success, or the value of errno on failure (which indicates the failure reason)*/
-  IBV_INT_CHECK_RET_ERRNO(ibv_internal_dealloc_pd, ibv_internal_dealloc_pd(pd), 0, "ibv_dealloc_pd");
+  ncclResult_t res;
+  IBV_INT_CHECK_RET_ERRNO_NO_RETURN(ibv_internal_dealloc_pd, ibv_internal_dealloc_pd(pd), 0, "ibv_dealloc_pd", res);
+  return res;
 }
 
 ncclResult_t wrap_ibv_reg_mr(struct ibv_mr **ret, struct ibv_pd *pd, void *addr, size_t length, int access) {
-  IBV_PTR_CHECK_ERRNO(ibv_internal_reg_mr, ibv_internal_reg_mr(pd, addr, length, access), *ret, NULL, "ibv_reg_mr");
+  ncclResult_t res;
+  IBV_PTR_CHECK_ERRNO_NO_RETURN(ibv_internal_reg_mr, ibv_internal_reg_mr(pd, addr, length, access), *ret, NULL, "ibv_reg_mr", res);
+  return res;
 }
 
 struct ibv_mr * wrap_direct_ibv_reg_mr(struct ibv_pd *pd, void *addr, size_t length, int access) {
@@ -280,12 +311,16 @@ ncclResult_t wrap_ibv_reg_mr_iova2(struct ibv_mr **ret, struct ibv_pd *pd, void 
     return ncclInternalError;
   }
   if (ret == NULL) { return ncclSuccess; } // Assume dummy call
-  IBV_PTR_CHECK_ERRNO(ibv_internal_reg_mr_iova2, ibv_internal_reg_mr_iova2(pd, addr, length, iova, access), *ret, NULL, "ibv_reg_mr_iova2");
+  ncclResult_t res;
+  IBV_PTR_CHECK_ERRNO_NO_RETURN(ibv_internal_reg_mr_iova2, ibv_internal_reg_mr_iova2(pd, addr, length, iova, access), *ret, NULL, "ibv_reg_mr_iova2", res);
+  return res;
 }
 
 /* DMA-BUF support */
 ncclResult_t wrap_ibv_reg_dmabuf_mr(struct ibv_mr **ret, struct ibv_pd *pd, uint64_t offset, size_t length, uint64_t iova, int fd, int access) {
-  IBV_PTR_CHECK_ERRNO(ibv_internal_reg_dmabuf_mr, ibv_internal_reg_dmabuf_mr(pd, offset, length, iova, fd, access), *ret, NULL, "ibv_reg_dmabuf_mr");
+  ncclResult_t res;
+  IBV_PTR_CHECK_ERRNO_NO_RETURN(ibv_internal_reg_dmabuf_mr, ibv_internal_reg_dmabuf_mr(pd, offset, length, iova, fd, access), *ret, NULL, "ibv_reg_dmabuf_mr", res);
+  return res;
 }
 
 struct ibv_mr * wrap_direct_ibv_reg_dmabuf_mr(struct ibv_pd *pd, uint64_t offset, size_t length, uint64_t iova, int fd, int access) {
@@ -296,27 +331,39 @@ struct ibv_mr * wrap_direct_ibv_reg_dmabuf_mr(struct ibv_pd *pd, uint64_t offset
 }
 
 ncclResult_t wrap_ibv_dereg_mr(struct ibv_mr *mr) { /*returns 0 on success, or the value of errno on failure (which indicates the failure reason)*/
-  IBV_INT_CHECK_RET_ERRNO(ibv_internal_dereg_mr, ibv_internal_dereg_mr(mr), 0, "ibv_dereg_mr");
+  ncclResult_t res;
+  IBV_INT_CHECK_RET_ERRNO_NO_RETURN(ibv_internal_dereg_mr, ibv_internal_dereg_mr(mr), 0, "ibv_dereg_mr", res);
+  return res;
 }
 
 ncclResult_t wrap_ibv_create_cq(struct ibv_cq **ret, struct ibv_context *context, int cqe, void *cq_context, struct ibv_comp_channel *channel, int comp_vector) {
-  IBV_PTR_CHECK(ibv_internal_create_cq, ibv_internal_create_cq(context, cqe, cq_context, channel, comp_vector), *ret, NULL, "ibv_create_cq");
+  ncclResult_t res;
+  IBV_PTR_CHECK_NO_RETURN(ibv_internal_create_cq, ibv_internal_create_cq(context, cqe, cq_context, channel, comp_vector), *ret, NULL, "ibv_create_cq", res);
+  return res;
 }
 
 ncclResult_t wrap_ibv_destroy_cq(struct ibv_cq *cq) {
-  IBV_INT_CHECK_RET_ERRNO(ibv_internal_destroy_cq, ibv_internal_destroy_cq(cq), 0, "ibv_destroy_cq");
+  ncclResult_t res;
+  IBV_INT_CHECK_RET_ERRNO_NO_RETURN(ibv_internal_destroy_cq, ibv_internal_destroy_cq(cq), 0, "ibv_destroy_cq", res);
+  return res;
 }
 
 ncclResult_t wrap_ibv_destroy_qp(struct ibv_qp *qp) {
-  IBV_INT_CHECK_RET_ERRNO(ibv_internal_destroy_qp, ibv_internal_destroy_qp(qp), 0, "ibv_destroy_qp");
+  ncclResult_t res;
+  IBV_INT_CHECK_RET_ERRNO_NO_RETURN(ibv_internal_destroy_qp, ibv_internal_destroy_qp(qp), 0, "ibv_destroy_qp", res);
+  return res;
 }
 
 ncclResult_t wrap_ibv_create_qp(struct ibv_qp **ret, struct ibv_pd *pd, struct ibv_qp_init_attr *qp_init_attr) {
-  IBV_PTR_CHECK(ibv_internal_create_qp, ibv_internal_create_qp(pd, qp_init_attr), *ret, NULL, "ibv_create_qp");
+  ncclResult_t res;
+  IBV_PTR_CHECK_NO_RETURN(ibv_internal_create_qp, ibv_internal_create_qp(pd, qp_init_attr), *ret, NULL, "ibv_create_qp", res);
+  return res;
 }
 
 ncclResult_t wrap_ibv_modify_qp(struct ibv_qp *qp, struct ibv_qp_attr *attr, int attr_mask) { /*returns 0 on success, or the value of errno on failure (which indicates the failure reason)*/
-  IBV_INT_CHECK_RET_ERRNO(ibv_internal_modify_qp, ibv_internal_modify_qp(qp, attr, attr_mask), 0, "ibv_modify_qp");
+  ncclResult_t res;
+  IBV_INT_CHECK_RET_ERRNO_NO_RETURN(ibv_internal_modify_qp, ibv_internal_modify_qp(qp, attr, attr_mask), 0, "ibv_modify_qp", res);
+  return res;
 }
 
 ncclResult_t wrap_ibv_event_type_str(char **ret, enum ibv_event_type event) {


### PR DESCRIPTION
Summary: This patch refactors all CHECK macros in ibvwrap.cc to NO_RETURN version which only sets ncclResult_t without return inside the macro. It allows profiling points to be inserted for ibv calls.

Differential Revision: D39749043

