### PR TITLE
add nccl window APIs to support RMA-like communication

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -28,7 +28,7 @@ LIBSRCFILES += ctran/backends/nvl/ctranNvl.cc ctran/backends/nvl/ctranNvlRequest
 LIBSRCFILES += ctran/mapper/ctranMapper.cc \
 							 ctran/mapper/ctranMapperRequest.cc ctran/mapper/ctranMapperMemPool.cc
 LIBSRCFILES += ctran/gpe/ctranGpe.cc ctran/gpe/ctranGpeImpl.cc
-LIBSRCFILES += ctran/frontend/ncclRegister.cc
+LIBSRCFILES += ctran/frontend/ncclRegister.cc ctran/frontend/ncclWin.cc
 LIBSRCFILES += ctran/algos/allGatherDirect.cc ctran/algos/allGatherRing.cc \
 							 ctran/algos/sendrecv.cc \
 							 ctran/algos/ctranAlgos.cc \

--- a/src/ctran/frontend/ncclWin.cc
+++ b/src/ctran/frontend/ncclWin.cc
@@ -1,0 +1,97 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "ncclWin.h"
+#include "argcheck.h"
+#include "bootstrap.h"
+#include "checks.h"
+#include "comm.h"
+
+// FIXME: should we expose baseptr to user since users have to query anyway?
+NCCL_API(
+    ncclResult_t,
+    ncclWinAllocShared,
+    size_t size,
+    ncclComm_t comm,
+    ncclWin_t* win);
+ncclResult_t ncclWinAllocShared(size_t size, ncclComm_t comm, ncclWin_t* win) {
+  bool can_use_win =
+      (comm->nNodes == 1 && comm->nRanks == comm->localRanks &&
+       comm->ctranMapper);
+  int nRanks = comm->nRanks;
+  // FIXME: should be support sinlge process communicator?
+  if (!can_use_win) {
+    WARN(
+        "ncclCommWinAllocShared only supports intra-node collectives comm->nNodes %d, comm->nRanks %d, comm->localRanks %d",
+        comm->nNodes,
+        comm->nRanks,
+        comm->localRanks);
+    return ncclSuccess;
+  }
+  // TODO: sanity check to make sure all peers can use IPC
+
+  // allocate resources
+  ncclWin* win_ = static_cast<ncclWin*>(malloc(sizeof(ncclWin)));
+  win_->remotePtrs = static_cast<void**>(malloc(nRanks * sizeof(void*)));
+  win_->ipcHandles = static_cast<cudaIpcMemHandle_t*>(
+      malloc(nRanks * sizeof(cudaIpcMemHandle_t)));
+
+  // get memory from mapper's pool
+  void *addr, *hdl;
+  comm->ctranMapper->getTmpBuf(&addr, size, &hdl);
+  // open IPC handle
+  CUDACHECK(cudaIpcGetMemHandle(
+      (cudaIpcMemHandle_t*)&win_->ipcHandles[comm->rank], (void*)addr));
+
+  // exchange IPC handles
+  NCCLCHECK(bootstrapAllGather(
+      comm->bootstrap, win_->ipcHandles, sizeof(cudaIpcMemHandle_t)));
+
+  // open IPC handles and cache remote  address
+  for (int i = 0; i < nRanks; ++i) {
+    void* remoteAddr;
+    if (i != comm->rank) {
+      CUDACHECK(cudaIpcOpenMemHandle(
+          (void**)&remoteAddr,
+          win_->ipcHandles[i],
+          cudaIpcMemLazyEnablePeerAccess));
+    } else {
+      remoteAddr = addr;
+    }
+  }
+
+  *win = win_;
+  return ncclSuccess;
+}
+
+NCCL_API(
+    ncclResult_t,
+    ncclWinSharedQuery,
+    int rank,
+    ncclComm_t comm,
+    ncclWin_t win,
+    void** addr);
+ncclResult_t
+ncclWinSharedQuery(int rank, ncclComm_t comm, ncclWin_t win, void** addr) {
+  *addr = win->remotePtrs[rank];
+
+  return ncclSuccess;
+}
+
+NCCL_API(ncclResult_t, ncclWinFree, ncclComm_t comm, ncclWin_t win);
+ncclResult_t ncclWinFree(ncclComm_t comm, ncclWin_t win) {
+  INFO(NCCL_INIT, "freeing window");
+  for (int i = 0; i < comm->nRanks; ++i) {
+    if (i != comm->rank) {
+      CUDACHECK(cudaIpcCloseMemHandle((void*)win->remotePtrs[i]));
+    }
+  }
+  // FIXME: segfault
+  comm->ctranMapper->releaseTmpBuf(win->remotePtrs[comm->rank], nullptr);
+
+  free(win->remotePtrs);
+  free(win->ipcHandles);
+  free(win);
+
+  INFO(NCCL_INIT, "freed window");
+  return ncclSuccess;
+}

--- a/src/ctran/frontend/ncclWin.h
+++ b/src/ctran/frontend/ncclWin.h
@@ -1,0 +1,19 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#ifndef CTRAN_WIN_H_
+#define CTRAN_WIN_H_
+
+#include <cstdint>
+#include <vector>
+#include "nccl.h"
+#include "cuda_runtime.h"
+
+// constexpr int kNCCLMaxDevices = 16;
+
+struct ncclWin {
+    ncclComm_t *comm;
+    void** remotePtrs;
+    cudaIpcMemHandle_t* ipcHandles;
+};
+
+#endif // CTRAN_WIN_H_

--- a/src/nccl.h.in
+++ b/src/nccl.h.in
@@ -30,6 +30,7 @@ extern "C" {
 #include <stdint.h>
 
 #define NCCL_REGISTRATION_SUPPORTED
+#define NCCL_RMA_SUPPORTED
 
 /* Opaque handle to communicator */
 typedef struct ncclComm* ncclComm_t;
@@ -37,6 +38,8 @@ typedef struct ncclComm* ncclComm_t;
 
 #define NCCL_UNIQUE_ID_BYTES 128
 typedef struct { char internal[NCCL_UNIQUE_ID_BYTES]; } ncclUniqueId;
+
+typedef struct ncclWin* ncclWin_t;
 
 /* Error type */
 typedef enum { ncclSuccess                 =  0,
@@ -497,6 +500,25 @@ ncclResult_t pncclGroupStart();
  */
 ncclResult_t  ncclGroupEnd();
 ncclResult_t pncclGroupEnd();
+
+/*
+ * Create a window object for one-sided communication and shared memory access
+ * and allocate memory at each process.
+ */
+ncclResult_t  ncclWinAllocShared(size_t size, ncclComm_t comm, ncclWin_t* win);
+ncclResult_t pncclWinAllocShared(size_t size, ncclComm_t comm, ncclWin_t* win);
+
+/*
+ * Query remote address cached in the window object
+ */
+ncclResult_t  ncclWinSharedQuery(int peer, ncclComm_t comm, ncclWin_t win, void **addr);
+ncclResult_t pncclWinSharedQuery(int peer, ncclComm_t comm, ncclWin_t win, void **addr);
+
+/*
+ * Free the window object and free the allocated memory
+ */
+ncclResult_t  ncclWinFree(ncclComm_t comm, ncclWin_t win);
+ncclResult_t pncclWinFree(ncclComm_t comm, ncclWin_t win);
 
 #ifdef __cplusplus
 } // end extern "C"


### PR DESCRIPTION
Summary:
Adding three new MPIs to support basic functionality of one-sided communication (i.e., similar to MPI)
1. `ncclWinAllocShared`: create a window with memory allocation to be shared among GPUs within the node
  - each GPU allocate a CUDA buffer (get from the free memory pool if available) and get IPC memory handle
  - use boostrap allgather to exchange IPC handles
  - open IPC handles to get remote address to be used later

2. `ncclWinSharedQuery`: query call to get remote address for  performing IPC-like communication

3. `ncclWinFree`: close IPC handles and free allocated resources

Limitations:
- only support intra-node case
- rely on nccl boostrapAllgather (can implement a SHM function as well)
-  Application must query the remote address by calling `ncclWinSharedQuery` to get the remote address since the shared memory region is not contiguous among GPUs (might be possible to make them contiguous using CUDA driver APIs, which can be explored later)

Differential Revision: D50910075


