### PR TITLE
add macro for check with exception

### DIFF
--- a/src/ctran/mapper/CtranMapper.cc
+++ b/src/ctran/mapper/CtranMapper.cc
@@ -14,6 +14,7 @@
 #include "bootstrap.h"
 #include "comm.h"
 #include "nccl_cvars.h"
+#include "CtranChecks.h"
 
 /*
 === BEGIN_NCCL_CVAR_INFO_BLOCK ===
@@ -153,7 +154,6 @@ static void recordRegistDuration(
 }
 
 CtranMapper::CtranMapper(ncclComm* comm) {
-  ncclResult_t res = ncclSuccess;
   this->pimpl_ = std::unique_ptr<impl>(new impl());
 
   /* mapperRegElemList */
@@ -202,8 +202,8 @@ CtranMapper::CtranMapper(ncclComm* comm) {
   this->pimpl_->totalNumRegLookupHit = 0;
   this->pimpl_->totalNumRegLookupMiss = 0;
 
-  CUDACHECKGOTO(
-      cudaStreamCreateWithFlags(&this->internalStream, cudaStreamNonBlocking), res, fail);
+  CUDACHECKTHROW(
+      cudaStreamCreateWithFlags(&this->internalStream, cudaStreamNonBlocking));
 
   this->rank = comm->rank;
   this->commHash = comm->commHash;
@@ -216,9 +216,6 @@ CtranMapper::CtranMapper(ncclComm* comm) {
 
   this->bootstrapTopology(comm);
   return;
-
-fail:
-  throw std::runtime_error("Failed to initialize CtranMapper");
 }
 
 void CtranMapper::reportRegSnapshot(void) {

--- a/src/ctran/utils/CtranChecks.h
+++ b/src/ctran/utils/CtranChecks.h
@@ -1,0 +1,33 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "debug.h"
+
+#ifndef CTRAN_CHECKS_H_
+#define CTRAN_CHECKS_H_
+
+#define CUDACHECKTHROW(cmd)                                        \
+  do {                                                              \
+    cudaError_t err = cmd;                                          \
+    if (err != cudaSuccess) {                                       \
+      WARN(                                                         \
+          "%s:%d Cuda failure '%s'",                                \
+          __FILE__,                                                 \
+          __LINE__,                                                 \
+          cudaGetErrorString(err));                                 \
+      (void)cudaGetLastError();                                     \
+      throw std::runtime_error(                                     \
+          std::string("Cuda failure: ") + cudaGetErrorString(err)); \
+    }                                                               \
+  } while (false)
+
+#define NCCLCHECKTHROW(cmd)                                             \
+  do {                                                                   \
+    ncclResult_t RES = cmd;                                              \
+    if (RES != ncclSuccess && RES != ncclInProgress) {                   \
+      WARN("%s:%d -> %d", __FILE__, __LINE__, RES);                      \
+      throw std::runtime_error(                                          \
+          std::string("NCCL internal failure: ") + std::to_string(RES)); \
+    }                                                                    \
+  } while (0)
+
+#endif


### PR DESCRIPTION
Summary:
With previous approach using `CUDACHECKGOTO`|`NCCLCHECKGOTO`, it required `ncclResult_t res` variable and a goto label. C++ compiler complains `res` is set but not used.

It is more straightforward to just throw the exception within the CHECK macro.

This patch defines `CUDACHECKTHROW` and `NCCLCHECKTHROW` macros for error checking in ctran constructors.

Reviewed By: cenzhaometa

Differential Revision: D53187428


