### PR TITLE
introduce ncclCommDump

### DIFF
--- a/examples/HelloWorld.cc
+++ b/examples/HelloWorld.cc
@@ -29,6 +29,18 @@ int main(int argc, char* argv[]) {
   printf("ncclCommHash %lx\n", ncclCommHash);
 #endif
 
+#ifdef NCCL_COMM_DUMP
+  std::unordered_map<std::string, std::string> dump;
+  NCCLCHECK(ncclCommDump(comm, dump));
+  for (auto& it : dump) {
+    printf(
+        "Dump from comm %p %s: %s\n",
+        comm,
+        it.first.c_str(),
+        it.second.c_str());
+  }
+#endif
+
   CUDACHECK(cudaFree(userBuff));
   CUDACHECK(cudaSetDevice(localRank));
   CUDACHECK(cudaStreamDestroy(stream));

--- a/src/Makefile
+++ b/src/Makefile
@@ -46,6 +46,7 @@ LIBSRCFILES += colltrace/CollTrace.cc
 LIBSRCFILES += colltrace/ProxyTrace.cc colltrace/ProxyMock.cc
 LIBSRCFILES += window.cc
 LIBSRCFILES += commHash.cc
+LIBSRCFILES += commDump.cc
 
 INCLUDES := -Iinclude
 INCLUDES += -Ialgorithms -Ialgorithms/allreduce

--- a/src/colltrace/ProxyTrace.cc
+++ b/src/colltrace/ProxyTrace.cc
@@ -307,11 +307,13 @@ static std::vector<std::string> infoKeys = {
 
 std::string ProxyTraceColl::serialize(bool quoted) {
   std::unordered_map<std::string, std::string> map;
-  map["commHash"] = hashToHexStr(collInfo.commHash);
+  map["commHash"] = quoted ? toQuotedString(hashToHexStr(collInfo.commHash))
+                           : hashToHexStr(collInfo.commHash);
   map["opCount"] = std::to_string(collInfo.opCount);
   map["coll"] = quoted ? toQuotedString(proxyCollStr[collInfo.coll])
                        : proxyCollStr[collInfo.coll];
-  map["channelIds"] = unorderedSetToStr(channelIds);
+  map["channelIds"] = quoted ? toQuotedString(unorderedSetToStr(channelIds))
+                             : unorderedSetToStr(channelIds);
   map["totalSendSize"] = std::to_string(totalSendSize);
   map["totalRecvSize"] = std::to_string(totalRecvSize);
   map["nProxyOps"] = std::to_string(nProxyOps);
@@ -341,7 +343,8 @@ static std::vector<std::string> entryKeys = {
 
 std::string ProxyTraceOp::serialize(bool quoted) {
   std::unordered_map<std::string, std::string> map;
-  map["commHash"] = hashToHexStr(collInfo.commHash);
+  map["commHash"] = quoted ? toQuotedString(hashToHexStr(collInfo.commHash))
+                           : hashToHexStr(collInfo.commHash);
   map["opCount"] = std::to_string(collInfo.opCount);
   map["coll"] = quoted ? toQuotedString(proxyCollStr[collInfo.coll])
                        : proxyCollStr[collInfo.coll];

--- a/src/colltrace/TraceUtils.h
+++ b/src/colltrace/TraceUtils.h
@@ -3,6 +3,7 @@
 #define TRACE_UTILES_H
 
 #include <chrono>
+#include <deque>
 #include <iomanip>
 #include <list>
 #include <sstream>
@@ -100,6 +101,24 @@ static inline std::string serializeList(std::list<T>& list) {
   std::string final_string = "[";
   for (auto& it : list) {
     final_string += toString(it);
+    final_string += ", ";
+  }
+  if (final_string.size() > 1) {
+    final_string =
+        final_string.substr(0, final_string.size() - std::string(", ").size());
+  }
+  final_string += "]";
+  return final_string;
+}
+/**
+ * Serialize a deque of objects to json string. Require the object type has
+ * serialize function. Input arguments: deque: the deque object to be serialized
+ */
+template <typename T>
+static inline std::string serializeObjects(std::deque<T>& objs) {
+  std::string final_string = "[";
+  for (auto& obj : objs) {
+    final_string += obj.serialize(true /*quote*/);
     final_string += ", ";
   }
   if (final_string.size() > 1) {

--- a/src/commDump.cc
+++ b/src/commDump.cc
@@ -1,0 +1,102 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <iterator>
+#include <string>
+#include <unordered_map>
+#include "CollTrace.h"
+#include "ExtUtils.h"
+#include "ProxyTrace.h"
+#include "TraceUtils.h"
+#include "comm.h"
+#include "nccl.h"
+
+static void dumpCommInfo(
+    ncclComm_t comm,
+    std::unordered_map<std::string, std::string>& map) {
+  map["commHash"] = std::to_string(comm->commHash);
+  map["rank"] = std::to_string(comm->rank);
+  map["nRanks"] = std::to_string(comm->nRanks);
+  map["localRank"] = std::to_string(comm->localRank);
+  map["localRanks"] = std::to_string(comm->localRanks);
+  map["node"] = std::to_string(comm->node);
+  map["nNodes"] = std::to_string(comm->nNodes);
+}
+
+static std::string dumpRing(int* userRanks, int nRank) {
+  std::vector<std::string> ringVec;
+  ringVec.reserve(nRank);
+  for (int i = 0; i < nRank; i++) {
+    ringVec.emplace_back(std::to_string(userRanks[i]));
+  }
+  return serializeVec(ringVec);
+}
+
+static void dumpCollTrace(
+    ncclComm_t comm,
+    std::unordered_map<std::string, std::string>& map) {
+  if (comm->collTrace != nullptr) {
+    auto dump = comm->collTrace->dump();
+
+    INFO(
+        NCCL_ALL,
+        "CommDump: COLLTRACE dump from rank %d comm %p commHash %lx: %zu past, %zu pending, %d current collective records",
+        comm->rank,
+        comm,
+        comm->commHash,
+        dump.pastColls.size(),
+        dump.pendingColls.size(),
+        dump.currentColl == nullptr ? 0 : 1);
+
+
+    map["CT_pastColls"] = serializeObjects(dump.pastColls);
+    map["CT_pendingColls"] = serializeObjects(dump.pendingColls);
+
+    if (dump.currentColl != nullptr) {
+      map["CT_currentColl"] = dump.currentColl->serialize(true);
+
+      auto algorithm = dump.currentColl->info.algorithm;
+      auto channelId = dump.currentColl->info.channelId;
+      if (algorithm == NCCL_ALGO_RING) {
+        map["CT_currentRing"] =
+            dumpRing(comm->channels[channelId].ring.userRanks, comm->nRanks);
+      }
+    } else {
+      map["CT_currentColl"] = "null";
+      map["CT_currentRing"] = "[]";
+    }
+  } else {
+    INFO(NCCL_ALL, "CommDump: COLLTRACE is disabled. No trace to dump");
+  }
+}
+
+static void dumpProxyTrace(
+    ncclComm_t comm,
+    std::unordered_map<std::string, std::string>& map) {
+  if (comm->proxyState != nullptr && comm->proxyState->trace) {
+    auto dump = comm->proxyState->trace->dump(comm->commHash);
+
+    INFO(
+        NCCL_ALL,
+        "CommDump: PROXYTRACE dump from rank %d comm %p commHash %lx: %zu past collectives, %zu active network operations",
+        comm->rank,
+        comm,
+        comm->commHash,
+        dump.pastColls.size(),
+        dump.activeOps.size());
+
+    map["PT_pastColls"] = serializeObjects(dump.pastColls);
+    map["PT_activeOps"] = serializeObjects(dump.activeOps);
+  } else {
+    INFO(NCCL_ALL, "CommDump: PROXYTRACE is disabled. No trace to dump");
+  }
+}
+
+__attribute__((visibility("default"))) ncclResult_t ncclCommDump(
+    ncclComm_t comm,
+    std::unordered_map<std::string, std::string>& map) {
+  dumpCommInfo(comm, map);
+  dumpCollTrace(comm, map);
+  dumpProxyTrace(comm, map);
+
+  return ncclSuccess;
+}

--- a/src/nccl.h.in
+++ b/src/nccl.h.in
@@ -38,6 +38,7 @@ extern "C" {
 #define NCCL_ALLTOALLV_SUPPORTED
 #define NCCL_ALLTOALL_SUPPORTED
 #define NCCL_COMM_GET_UNIQUE_HASH
+#define NCCL_COMM_DUMP
 
 #ifndef __CUDA_FP8_TYPES_EXIST__
 #undef NCCL_ENABLE_FP8
@@ -593,5 +594,11 @@ ncclResult_t  pncclCommGetUniqueHash(ncclComm_t comm, uint64_t* uniqueHash);
 #ifdef __cplusplus
 } // end extern "C"
 #endif
+
+#include <unordered_map>
+#include <string>
+/* Dump NCCL current internal state for a given communicator in a key-value store format.
+ * define outside extern "C"{} to pass C++ template */
+ncclResult_t  ncclCommDump(ncclComm_t comm, std::unordered_map<std::string, std::string>& map);
 
 #endif // end include guard

--- a/src/tests/CommDumpTest.cc
+++ b/src/tests/CommDumpTest.cc
@@ -1,0 +1,349 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+#include <nccl.h>
+#include <exception>
+#include <iostream>
+#include <string>
+#include <unordered_map>
+#include "ProxyMock.h"
+#include "comm.h"
+#include "json/json.h"
+#include "nccl_cvars.h"
+#include "tests_common.cuh"
+
+static bool VERBOSE = true;
+
+class MPIEnvironment : public ::testing::Environment {
+ public:
+  void SetUp() override {
+    initializeMpi(0, NULL);
+    setenv("NCCL_DEBUG", "WARN", 0);
+    setenv("NCCL_COLLTRACE", "trace", 0);
+    setenv("NCCL_PROXYTRACE", "trace", 0);
+  }
+
+  void TearDown() override {
+    finalizeMpi();
+  }
+
+  ~MPIEnvironment() override {}
+};
+
+class CommDumpTest : public ::testing::Test {
+ public:
+  CommDumpTest() = default;
+
+  void SetUp() override {
+    std::tie(this->localRank, this->globalRank, this->numRanks) = getMpiInfo();
+    this->comm =
+        createNcclComm(this->globalRank, this->numRanks, this->localRank);
+    CUDACHECK_TEST(cudaStreamCreate(&stream));
+
+    // Prepare data for sanity check after commSplit
+    CUDACHECK_TEST(cudaMalloc(&this->dataBuf, sizeof(int) * this->dataCount));
+  }
+
+  void initData(int myRank) {
+    std::vector<int> initVals(this->dataCount);
+    for (int i = 0; i < this->dataCount; i++) {
+      initVals[i] = i * myRank;
+    }
+    CUDACHECK_TEST(cudaMemcpy(
+        this->dataBuf,
+        initVals.data(),
+        sizeof(int) * this->dataCount,
+        cudaMemcpyHostToDevice));
+  }
+
+  void TearDown() override {
+    CUDACHECK_TEST(cudaFree(this->dataBuf));
+    CUDACHECK_TEST(cudaStreamDestroy(this->stream));
+    NCCLCHECK_TEST(ncclCommDestroy(this->comm));
+  }
+
+  int localRank{0};
+  int globalRank{0};
+  int numRanks{0};
+  int* dataBuf{nullptr};
+  const int dataCount{65536};
+  ncclComm_t comm;
+  cudaStream_t stream;
+};
+
+TEST_F(CommDumpTest, SingleComm) {
+  auto res = ncclSuccess;
+  std::unordered_map<std::string, std::string> dump;
+
+  res = ncclCommDump(this->comm, dump);
+  ASSERT_EQ(res, ncclSuccess);
+
+  EXPECT_EQ(dump.count("commHash"), 1);
+  EXPECT_EQ(dump["commHash"], std::to_string(this->comm->commHash));
+  EXPECT_EQ(dump.count("rank"), 1);
+  EXPECT_EQ(dump["rank"], std::to_string(this->comm->rank));
+  EXPECT_EQ(dump.count("nRanks"), 1);
+  EXPECT_EQ(dump["nRanks"], std::to_string(this->comm->nRanks));
+  EXPECT_EQ(dump.count("localRank"), 1);
+  EXPECT_EQ(dump["localRank"], std::to_string(this->comm->localRank));
+  EXPECT_EQ(dump.count("localRanks"), 1);
+  EXPECT_EQ(dump["localRanks"], std::to_string(this->comm->localRanks));
+  EXPECT_EQ(dump.count("node"), 1);
+  EXPECT_EQ(dump["node"], std::to_string(this->comm->node));
+  EXPECT_EQ(dump.count("nNodes"), 1);
+  EXPECT_EQ(dump["nNodes"], std::to_string(this->comm->nNodes));
+
+  EXPECT_EQ(dump.count("CT_pastColls"), 1);
+  EXPECT_EQ(dump.count("CT_pendingColls"), 1);
+  EXPECT_EQ(dump.count("CT_currentColl"), 1);
+  EXPECT_EQ(dump.count("CT_currentRing"), 1);
+
+  EXPECT_EQ(dump.count("PT_pastColls"), 1);
+  EXPECT_EQ(dump.count("PT_activeOps"), 1);
+}
+
+TEST_F(CommDumpTest, DumpAfterColl) {
+  auto res = ncclSuccess;
+  std::unordered_map<std::string, std::string> dump;
+  constexpr int numColls = 10;
+
+  // commHash is intentially stored as hex string for readability
+  std::stringstream commHashSs;
+  commHashSs << std::hex << comm->commHash;
+  std::string commHashStr = commHashSs.str();
+
+  this->initData(this->globalRank);
+  for (int i = 0; i < numColls; i++) {
+    NCCLCHECK_TEST(ncclAllReduce(
+        this->dataBuf,
+        this->dataBuf,
+        this->dataCount,
+        ncclInt,
+        ncclSum,
+        this->comm,
+        this->stream));
+  }
+  CUDACHECK_TEST(cudaStreamSynchronize(this->stream));
+
+  // FIXME: last a few tail sends may not be finished when kernel is done;
+  // Sleep 3 sec to wait as workaround. We need add a hook to check for proxy
+  // completion
+  sleep(3);
+
+  res = ncclCommDump(this->comm, dump);
+  ASSERT_EQ(res, ncclSuccess);
+
+  EXPECT_EQ(dump.count("CT_pastColls"), 1);
+  EXPECT_EQ(dump.count("CT_pendingColls"), 1);
+  EXPECT_EQ(dump.count("CT_currentColl"), 1);
+  EXPECT_EQ(dump.count("CT_currentRing"), 1);
+  EXPECT_EQ(dump.count("PT_pastColls"), 1);
+  EXPECT_EQ(dump.count("PT_activeOps"), 1);
+
+  // Check past collectives are dumped correctly and simply check if can be
+  // parsed as json entries.
+  if (dump.count("CT_pastColls")) {
+    Json::Value ctPastCollsObjs;
+    std::stringstream(dump["CT_pastColls"]) >> ctPastCollsObjs;
+    EXPECT_EQ(ctPastCollsObjs.size(), numColls);
+    for (int i = 0; i < numColls; i++) {
+      EXPECT_EQ(ctPastCollsObjs[i]["opCount"].asUInt64(), i);
+    }
+  }
+
+  // Proxy trace would be empty if nNodes == 1
+  if (dump.count("PT_pastColls") && comm->nNodes > 1) {
+    Json::Value ptPastCollsObjs;
+    std::stringstream(dump["PT_pastColls"]) >> ptPastCollsObjs;
+    EXPECT_EQ(ptPastCollsObjs.size(), numColls);
+    for (int i = 0; i < numColls; i++) {
+      EXPECT_EQ(ptPastCollsObjs[i]["commHash"].asString(), commHashStr);
+      EXPECT_EQ(ptPastCollsObjs[i]["opCount"].asUInt64(), i);
+    }
+  }
+
+  // Check no pending/current entries
+  if (dump.count("CT_pendingColls")) {
+    Json::Value ctPendingCollsObjs;
+    std::stringstream(dump["CT_pendingColls"]) >> ctPendingCollsObjs;
+    EXPECT_EQ(ctPendingCollsObjs.size(), 0);
+  }
+
+  if (dump.count("CT_currentColl")) {
+    EXPECT_EQ(dump["CT_currentColl"], "null");
+  }
+
+  if (dump.count("CT_currentRing")) {
+    Json::Value ctCurrentRingObj;
+    std::stringstream(dump["CT_currentRing"]) >> ctCurrentRingObj;
+    EXPECT_EQ(ctCurrentRingObj.size(), 0);
+  }
+
+  if (dump.count("PT_activeOps")) {
+    Json::Value ptActiveOpsObjs;
+    std::stringstream(dump["PT_activeOps"]) >> ptActiveOpsObjs;
+    EXPECT_EQ(ptActiveOpsObjs.size(), 0);
+  }
+
+  if (comm->rank == 0 && VERBOSE) {
+    for (auto& it : dump) {
+      printf("%s: %s\n", it.first.c_str(), it.second.c_str());
+    }
+  }
+}
+
+TEST_F(CommDumpTest, DumpDuringColl) {
+  auto res = ncclSuccess;
+  std::unordered_map<std::string, std::string> dump;
+  constexpr int numColls = 10;
+
+  if (comm->nNodes < 2) {
+    GTEST_SKIP() << "Skipping test since nNodes < 2";
+  }
+
+  // commHash is intentially stored as hex string for readability
+  std::stringstream commHashSs;
+  commHashSs << std::hex << comm->commHash;
+  std::string commHashStr = commHashSs.str();
+
+  // Manually set the hanging point at opCount 5
+  constexpr int hangOpCount = 5;
+  constexpr int hangRank = 0;
+  NCCL_PROXYMOCK_NET_SEND_FAILURE.clear();
+  NCCL_PROXYMOCK_NET_SEND_FAILURE.push_back(std::to_string(hangOpCount));
+  NCCL_PROXYMOCK_NET_SEND_FAILURE.push_back(std::to_string(hangRank));
+  NCCL_PROXYMOCK_NET_SEND_FAILURE.push_back("-1");
+  NCCL_PROXYMOCK_NET_SEND_FAILURE.push_back("-1");
+  NCCL_PROXYMOCK_NET_SEND_FAILURE.push_back("1"); // match only once
+  NCCL_PROXYMOCK_NET_SEND_FAILURE.push_back("30"); // delay 30 seconds
+
+  // Manually re-initialze state of the mock instance
+  auto& instance = ProxyMockNetSendFailure::getInstance();
+  instance.initialize();
+
+  this->initData(this->globalRank);
+  for (int i = 0; i < numColls; i++) {
+    NCCLCHECK_TEST(ncclAllReduce(
+        this->dataBuf,
+        this->dataBuf,
+        this->dataCount,
+        ncclInt,
+        ncclSum,
+        this->comm,
+        this->stream));
+  }
+
+  // Wait till the hanging point is reached
+  sleep(10);
+
+  res = ncclCommDump(this->comm, dump);
+  ASSERT_EQ(res, ncclSuccess);
+
+  EXPECT_EQ(dump.count("CT_pastColls"), 1);
+  EXPECT_EQ(dump.count("CT_pendingColls"), 1);
+  EXPECT_EQ(dump.count("CT_currentColl"), 1);
+  EXPECT_EQ(dump.count("CT_currentRing"), 1);
+  EXPECT_EQ(dump.count("PT_pastColls"), 1);
+  EXPECT_EQ(dump.count("PT_activeOps"), 1);
+
+  // Check records are dumped correctly and simply check if can be
+  // parsed as json entries.
+
+  // PastColl: Except some ranks may stuck at the hanging opCount but some
+  // others may have finished and stuck at the next.
+  if (dump.count("CT_pastColls")) {
+    Json::Value ctPastCollsObjs;
+    std::stringstream(dump["CT_pastColls"]) >> ctPastCollsObjs;
+    size_t numPasts = ctPastCollsObjs.size();
+    // For CollTrace, we know rank 0 must be hanging at hangOpCount
+    if (comm->rank == hangRank) {
+      EXPECT_EQ(numPasts, hangOpCount);
+    } else {
+      EXPECT_TRUE(numPasts == hangOpCount || numPasts == hangOpCount + 1);
+    }
+  }
+
+  if (dump.count("PT_pastColls") && comm->nNodes > 1) {
+    Json::Value ptPastCollsObjs;
+    std::stringstream(dump["PT_pastColls"]) >> ptPastCollsObjs;
+    size_t numPasts = ptPastCollsObjs.size();
+    // For ProxyTrace, since rank A's proxy thread may serve rank B's network
+    // op, we cannot assume a exact hang point based on rank
+    EXPECT_TRUE(numPasts == hangOpCount || numPasts == hangOpCount + 1);
+  }
+
+  // Pending collectives
+  if (dump.count("CT_pendingColls")) {
+    Json::Value ctPendingCollsObjs;
+    std::stringstream(dump["CT_pendingColls"]) >> ctPendingCollsObjs;
+    size_t numPending = ctPendingCollsObjs.size();
+    if (comm->rank == hangRank) {
+      // should hang exactly at hangOpCount, and 1 current
+      EXPECT_EQ(numPending, numColls - hangOpCount - 1);
+    } else {
+      // may hang at hangOpCount or next
+      EXPECT_TRUE(
+          numPending == numColls - hangOpCount - 1 ||
+          numPending == numColls - hangOpCount - 2);
+    }
+  }
+
+  if (dump.count("CT_currentColl")) {
+    EXPECT_NE(dump["CT_currentColl"], "null");
+    Json::Value ctCurrentCollsObj;
+    std::stringstream(dump["CT_currentColl"]) >> ctCurrentCollsObj;
+    if (comm->rank == hangRank) {
+      EXPECT_EQ(ctCurrentCollsObj["opCount"].asUInt64(), hangOpCount);
+      EXPECT_EQ(ctCurrentCollsObj["opName"], "AllReduce");
+    }
+  }
+
+  if (dump.count("CT_currentRing")) {
+    Json::Value ctCurrentRingObj;
+    std::stringstream(dump["CT_currentRing"]) >> ctCurrentRingObj;
+    // Each ring should include all ranks
+    EXPECT_EQ(ctCurrentRingObj.size(), comm->nRanks);
+  }
+
+  if (dump.count("PT_activeOps")) {
+    Json::Value ptActiveOpsObjs;
+    std::stringstream(dump["PT_activeOps"]) >> ptActiveOpsObjs;
+    EXPECT_GT(ptActiveOpsObjs.size(), 0);
+
+    for (auto& op : ptActiveOpsObjs) {
+      EXPECT_TRUE(op["rank"].asInt() >= 0 && op["rank"].asInt() < comm->nRanks);
+      EXPECT_TRUE(
+          op["remoteRank"].asInt() >= 0 &&
+          op["remoteRank"].asInt() < comm->nRanks);
+      EXPECT_TRUE(op["opCount"].asUInt64() >= 0);
+      EXPECT_TRUE(op["coll"].asString() == "AllReduce");
+      EXPECT_TRUE(
+          op["opType"].asString() == "SEND" ||
+          op["opType"].asString() == "RECV");
+      EXPECT_EQ(op["commHash"].asString(), commHashStr);
+
+      // Each rank may hang at hangOpCount and/or hangOpCount + 1 and may see
+      // active ops in both opCounts
+      EXPECT_TRUE(
+          op["opCount"].asUInt64() == hangOpCount ||
+          op["opCount"].asUInt64() == hangOpCount + 1);
+    }
+
+    // Skip cross-rank check as already covered in ProxyTraceDistTest
+  }
+
+  // Now let's wait for all communication to finish
+  CUDACHECK_TEST(cudaStreamSynchronize(this->stream));
+
+  if (comm->rank == 0 && VERBOSE) {
+    for (auto& it : dump) {
+      printf("%s: %s\n", it.first.c_str(), it.second.c_str());
+    }
+  }
+}
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new MPIEnvironment);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Summary:
Introduce user facing API ncclCommDump. It internally dumps NCCL internal state including:
- Basic comm metadata
- Pending, past, current collective kernels via CollTrace
- Past collectives and active network operations from ProxyTrace.  

See details in design doc: https://docs.google.com/document/d/1ReXt2IKsjlzCUyi8bN4o5aFlmOYq7_FgduvOkqp95k4/edit?usp=sharing

Differential Revision: D53792058


