### PR TITLE
print file:func in WARN call stack

### DIFF
--- a/src/include/checks.h
+++ b/src/include/checks.h
@@ -32,7 +32,7 @@
 #define CUDACHECKIGNORE(cmd) do {  \
     cudaError_t err = cmd;         \
     if( err != cudaSuccess ) {     \
-        WARN("%s:%d Cuda failure '%s'", __FILE__, __LINE__, cudaGetErrorString(err)); \
+        WARN("%s:%s:%d Cuda failure '%s'", __FILE__, __func__, __LINE__, cudaGetErrorString(err)); \
         (void) cudaGetLastError(); \
     }                              \
 } while(false)
@@ -76,7 +76,7 @@
   if ((statement) == -1) {    \
     /* Print the back trace*/ \
     RES = ncclSystemError;    \
-    WARN("%s:%d -> %d (%s)", __FILE__, __LINE__, RES, strerror(errno));    \
+    WARN("%s:%s:%d -> %d (%s)", __FILE__, __func__, __LINE__, RES, strerror(errno));    \
     goto label; \
   } \
 } while (0);
@@ -84,7 +84,7 @@
 #define NEQCHECK(statement, value) do {   \
   if ((statement) != value) {             \
     /* Print the back trace*/             \
-    WARN("%s:%d -> %d (%s)", __FILE__, __LINE__, ncclSystemError, strerror(errno));    \
+    WARN("%s:%s:%d -> %d (%s)", __FILE__, __func__, __LINE__, ncclSystemError, strerror(errno));    \
     return ncclSystemError;     \
   }                             \
 } while (0);
@@ -93,7 +93,7 @@
   if ((statement) != value) { \
     /* Print the back trace*/ \
     RES = ncclSystemError;    \
-    WARN("%s:%d -> %d (%s)", __FILE__, __LINE__, RES, strerror(errno));    \
+    WARN("%s:%s:%d -> %d (%s)", __FILE__, __func__, __LINE__, RES, strerror(errno));    \
     goto label; \
   } \
 } while (0);
@@ -101,7 +101,7 @@
 #define EQCHECK(statement, value) do {    \
   if ((statement) == value) {             \
     /* Print the back trace*/             \
-    WARN("%s:%d -> %d (%s)", __FILE__, __LINE__, ncclSystemError, strerror(errno));    \
+    WARN("%s:%s:%d -> %d (%s)", __FILE__, __func__, __LINE__, ncclSystemError, strerror(errno));    \
     return ncclSystemError;     \
   }                             \
 } while (0);
@@ -110,7 +110,7 @@
   if ((statement) == value) { \
     /* Print the back trace*/ \
     RES = ncclSystemError;    \
-    WARN("%s:%d -> %d (%s)", __FILE__, __LINE__, RES, strerror(errno));    \
+    WARN("%s:%s:%d -> %d (%s)", __FILE__, __func__, __LINE__, RES, strerror(errno));    \
     goto label; \
   } \
 } while (0);
@@ -120,7 +120,7 @@
   ncclResult_t RES = call; \
   if (RES != ncclSuccess && RES != ncclInProgress) { \
     /* Print the back trace*/ \
-    if (ncclDebugNoWarn == 0) WARN("%s:%d -> %d (%s)", __FILE__, __LINE__, RES, ncclGetErrorString(RES));    \
+    if (ncclDebugNoWarn == 0) WARN("%s:%s:%d -> %d (%s)", __FILE__, __func__, __LINE__, RES, ncclGetErrorString(RES));    \
     return RES; \
   } \
 } while (0);
@@ -129,7 +129,7 @@
   RES = call; \
   if (RES != ncclSuccess && RES != ncclInProgress) { \
     /* Print the back trace*/ \
-    if (ncclDebugNoWarn == 0) WARN("%s:%d -> %d (%s)", __FILE__, __LINE__, RES, ncclGetErrorString(RES));    \
+    if (ncclDebugNoWarn == 0) WARN("%s:%s:%d -> %d (%s)", __FILE__, __func__, __LINE__, RES, ncclGetErrorString(RES));    \
     goto label; \
   } \
 } while (0);
@@ -139,7 +139,7 @@
   do {                                                        \
     ncclResult_t RES = call;                                  \
     if (RES != ncclSuccess && RES != ncclInProgress) {        \
-      WARN("%s:%d -> %d (%s)", __FILE__, __LINE__, RES, ncclGetErrorString(RES)); \
+      WARN("%s:%s:%d -> %d (%s)", __FILE__, __func__, __LINE__, RES, ncclGetErrorString(RES)); \
     }                                                         \
   } while (0)
 
@@ -149,7 +149,7 @@
   do {                                                 \
     ncclResult_t RES = call;                           \
     if (RES != ncclSuccess && RES != ncclInProgress) { \
-      WARN("%s:%d -> %d (%s)", __FILE__, __LINE__, RES, ncclGetErrorString(RES));    \
+      WARN("%s:%s:%d -> %d (%s)", __FILE__, __func__, __LINE__, RES, ncclGetErrorString(RES));    \
       abort();                                         \
     }                                                  \
   } while (0)
@@ -158,7 +158,7 @@
   volatile uint32_t* tmpAbortFlag = (abortFlagPtr);     \
   ncclResult_t RES = call;                \
   if (RES != ncclSuccess && RES != ncclInProgress) {               \
-    if (ncclDebugNoWarn == 0) WARN("%s:%d -> %d (%s)", __FILE__, __LINE__, RES, ncclGetErrorString(RES));    \
+    if (ncclDebugNoWarn == 0) WARN("%s:%s:%d -> %d (%s)", __FILE__, __func__, __LINE__, RES, ncclGetErrorString(RES));    \
     return ncclInternalError;             \
   }                                       \
   if (tmpAbortFlag) NEQCHECK(*tmpAbortFlag, 0); \
@@ -168,7 +168,7 @@
   volatile uint32_t* tmpAbortFlag = (abortFlagPtr);             \
   RES = call;                             \
   if (RES != ncclSuccess && RES != ncclInProgress) {               \
-    if (ncclDebugNoWarn == 0) WARN("%s:%d -> %d (%s)", __FILE__, __LINE__, RES, ncclGetErrorString(RES));    \
+    if (ncclDebugNoWarn == 0) WARN("%s:%s:%d -> %d (%s)", __FILE__, __func__, __LINE__, RES, ncclGetErrorString(RES));    \
     goto label;                           \
   }                                       \
   if (tmpAbortFlag) NEQCHECKGOTO(*tmpAbortFlag, 0, RES, label); \
@@ -176,14 +176,14 @@
 
 #define NCCLCHECKTHREAD(a, args) do { \
   if (((args)->ret = (a)) != ncclSuccess && (args)->ret != ncclInProgress) { \
-    WARN("%s:%d -> %d [Async thread]", __FILE__, __LINE__, (args)->ret); \
+    WARN("%s:%s:%d -> %d [Async thread]", __FILE__, __func__, __LINE__, (args)->ret); \
     return args; \
   } \
 } while(0)
 
 #define CUDACHECKTHREAD(a) do { \
   if ((a) != cudaSuccess) { \
-    WARN("%s:%d -> %d [Async thread]", __FILE__, __LINE__, args->ret); \
+    WARN("%s:%s:%d -> %d [Async thread]", __FILE__, __func__, __LINE__, args->ret); \
     args->ret = ncclUnhandledCudaError; \
     return args; \
   } \


### PR DESCRIPTION
Summary: When error happens, call stack is printed as WARN log. It includes file:line in current format. This patch updates it to file:func:line for easier troubleshooting.

Differential Revision: D55274256


