### PR TITLE
Print host name in addition to socket address

### DIFF
--- a/src/bootstrap.cc
+++ b/src/bootstrap.cc
@@ -104,6 +104,9 @@ static void *bootstrapRoot(void* rargs) {
   union ncclSocketAddress *rankAddresses = NULL;
   union ncclSocketAddress *rankAddressesRoot = NULL; // for initial rank <-> root information exchange
   union ncclSocketAddress *zero = NULL;
+
+  NCCL_NAMED_THREAD_START("BootStrapRoot");
+
   NCCLCHECKGOTO(ncclCalloc(&zero, 1), res, out);
   setFilesLimit();
 

--- a/src/bootstrap.cc
+++ b/src/bootstrap.cc
@@ -213,20 +213,6 @@ struct unexConn {
   struct unexConn* next;
 };
 
-struct bootstrapState {
-  struct ncclSocket listenSock;
-  struct ncclSocket ringRecvSocket;
-  struct ncclSocket ringSendSocket;
-  union ncclSocketAddress* peerCommAddresses;
-  union ncclSocketAddress* peerProxyAddresses;
-  struct unexConn* unexpectedConnections;
-  int cudaDev;
-  int rank;
-  int nranks;
-  uint64_t magic;
-  volatile uint32_t *abortFlag;
-};
-
 ncclResult_t bootstrapInit(struct ncclBootstrapHandle* handle, struct ncclComm* comm) {
   int rank = comm->rank;
   int nranks = comm->nRanks;

--- a/src/colltrace/CollTrace.cc
+++ b/src/colltrace/CollTrace.cc
@@ -198,6 +198,7 @@ CollTrace::Dump CollTrace::dump() {
 }
 
 void* CollTrace::collTraceThreadFn(CollTrace* ct) {
+  NCCL_NAMED_THREAD_START("CollTrace");
   return ct->collTraceThreadFnImpl();
 }
 

--- a/src/ctran/backends/ib/CtranIbImpl.cc
+++ b/src/ctran/backends/ib/CtranIbImpl.cc
@@ -14,6 +14,7 @@
 #include "ExtChecks.h"
 
 void CtranIb::Impl::bootstrapAccept(CtranIb::Impl *pimpl) {
+  NCCL_NAMED_THREAD_START("CTranIbListen");
   while (1) {
     struct ncclSocket sock;
     int peerRank;

--- a/src/ctran/gpe/CtranGpeImpl.cc
+++ b/src/ctran/gpe/CtranGpeImpl.cc
@@ -97,6 +97,8 @@ ncclResult_t CtranGpe::Impl::terminate() {
 }
 
 void CtranGpe::Impl::gpeThreadFn(CtranGpe::Impl* pimpl, int cudaDev) {
+  NCCL_NAMED_THREAD_START("CTranGPE");
+
   CUDACHECKTHROW(cudaSetDevice(cudaDev));
 
   while (1) {

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -61,6 +61,8 @@
 === END_NCCL_CVAR_INFO_BLOCK ===
 */
 
+std::mutex socketMapMutex{};
+std::unordered_map<std::string, std::string> socketIPv6ToHostname{};
 int ncclDebugLevel = -1;
 static int pid = -1;
 static char hostname[1024];

--- a/src/group.cc
+++ b/src/group.cc
@@ -60,6 +60,7 @@ ncclResult_t ncclAsyncLaunch(
 }
 
 void* ncclAsyncJobMain(void* arg) {
+  NCCL_NAMED_THREAD_START("AsyncJob");
   struct ncclAsyncJob* job = (struct ncclAsyncJob*)arg;
   job->result = job->func(job);
   if (job->result != ncclSuccess) {

--- a/src/include/bootstrap.h
+++ b/src/include/bootstrap.h
@@ -16,6 +16,20 @@ struct ncclBootstrapHandle {
 };
 static_assert(sizeof(struct ncclBootstrapHandle) <= sizeof(ncclUniqueId), "Bootstrap handle is too large to fit inside NCCL unique ID");
 
+struct bootstrapState {
+  struct ncclSocket listenSock;
+  struct ncclSocket ringRecvSocket;
+  struct ncclSocket ringSendSocket;
+  union ncclSocketAddress* peerCommAddresses;
+  union ncclSocketAddress* peerProxyAddresses;
+  struct unexConn* unexpectedConnections;
+  int cudaDev;
+  int rank;
+  int nranks;
+  uint64_t magic;
+  volatile uint32_t *abortFlag;
+};
+
 ncclResult_t bootstrapNetInit();
 ncclResult_t bootstrapCreateRoot(struct ncclBootstrapHandle* handle, bool idFromEnv);
 ncclResult_t bootstrapGetUniqueId(struct ncclBootstrapHandle* handle);

--- a/src/include/debug.h
+++ b/src/include/debug.h
@@ -46,6 +46,18 @@ extern std::chrono::steady_clock::time_point ncclEpoch;
 #endif
 
 void ncclSetThreadName(pthread_t thread, const char *fmt, ...);
+// Allow thread itsef to set its own name for logging purpose
+void ncclSetMyThreadLoggingName(const char *fmt, ...);
+
+#define NCCL_NAMED_THREAD_START(threadName)       \
+  do {                                            \
+    ncclSetMyThreadLoggingName(threadName);       \
+    INFO(                                         \
+        NCCL_INIT,                                \
+        "[NCCL THREAD] Starting %s thread at %s", \
+        threadName,                               \
+        __func__);                                \
+  } while (0);
 
 static inline std::string getTime(void) {
   auto now = std::chrono::system_clock::now();

--- a/src/include/debug.h
+++ b/src/include/debug.h
@@ -10,17 +10,23 @@
 #include "nccl_net.h"
 #include <stdio.h>
 #include <chrono>
+#include <mutex>
 #include <string>
 #include <type_traits>
+#include <vector>
 
 #include <limits.h>
 #include <string.h>
 #include <pthread.h>
 #include <sstream>
 #include <iomanip>
+#include <unordered_map>
 
 // Conform to pthread and NVTX standard
 #define NCCL_THREAD_NAMELEN 16
+
+extern std::mutex socketMapMutex;
+extern std::unordered_map<std::string, std::string> socketIPv6ToHostname;
 
 extern int ncclDebugLevel;
 extern uint64_t ncclDebugMask;

--- a/src/include/socket.h
+++ b/src/include/socket.h
@@ -23,6 +23,8 @@
 #define SOCKET_NAME_MAXLEN (NI_MAXHOST+NI_MAXSERV)
 #define NCCL_SOCKET_MAGIC 0x564ab9f2fc4b9d6cULL
 
+constexpr auto kMaxHostNameLen = 127; // Extra byte for NUL
+
 /* Common socket address storage structure for IPv4/IPv6 */
 union ncclSocketAddress {
   struct sockaddr sa;
@@ -66,6 +68,7 @@ struct ncclSocket {
   enum ncclSocketType type;
 };
 
+std::string ncclSocketToIPv6String(union ncclSocketAddress *addr);
 const char *ncclSocketToString(union ncclSocketAddress *addr, char *buf, const int numericHostForm = 1);
 ncclResult_t ncclSocketGetAddrFromString(union ncclSocketAddress* ua, const char* ip_port_pair);
 int ncclFindInterfaceMatchSubnet(char* ifNames, union ncclSocketAddress* localAddrs, union ncclSocketAddress* remoteAddr, int ifNameMaxSize, int maxIfs);

--- a/src/include/transport.h
+++ b/src/include/transport.h
@@ -43,6 +43,8 @@ struct ncclPeerInfo {
   int64_t busId;
   struct ncclComm* comm;
   int cudaCompCap;
+  pid_t pid;
+  char hostname[128];
 };
 
 #define CONNECT_SIZE 128

--- a/src/init.cc
+++ b/src/init.cc
@@ -28,6 +28,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <cstdlib>
+#include <mutex>
 
 /*
 === BEGIN_NCCL_CVAR_INFO_BLOCK ===
@@ -694,6 +695,9 @@ static ncclResult_t fillInfo(struct ncclComm* comm, struct ncclPeerInfo* info, u
   info->hostHash=getHostHash()+commHash;
   info->pidHash=getPidHash()+commHash;
 
+  gethostname(info->hostname, 128);
+  info->pid = getpid();
+
   // Get the device MAJOR:MINOR of /dev/shm so we can use that
   // information to decide whether we can use SHM for inter-process
   // communication in a container environment
@@ -963,6 +967,17 @@ fail:
   goto exit;
 }
 
+static void addPeerInfoToGlobal(struct ncclComm* comm) {
+  std::unique_lock<std::mutex> socketLock{socketMapMutex};
+  for (int i = 0; i < comm->nRanks; i++) {
+    auto state = static_cast<struct bootstrapState*>(comm->bootstrap);
+    std::string commSocketStr = ncclSocketToIPv6String(&state->peerCommAddresses[i]);
+    socketIPv6ToHostname.emplace(std::move(commSocketStr), comm->peerInfo[i].hostname);
+    std::string proxySocketStr = ncclSocketToIPv6String(&state->peerProxyAddresses[i]);
+    socketIPv6ToHostname.emplace(std::move(proxySocketStr), comm->peerInfo[i].hostname);
+  }
+}
+
 static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* parent = NULL) {
   // We use 2 AllGathers
   // 1. { peerInfo, comm, compCap}
@@ -1007,6 +1022,8 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   NCCLCHECKGOTO(ncclCalloc(&comm->peerInfo, nranks+1), ret, fail); // Extra rank to represent CollNet root
   NCCLCHECKGOTO(fillInfo(comm, comm->peerInfo+rank, comm->commHash), ret, fail);
   NCCLCHECKGOTO(bootstrapAllGather(comm->bootstrap, comm->peerInfo, sizeof(struct ncclPeerInfo)), ret, fail);
+
+  addPeerInfoToGlobal(comm);
 
   for (int i = 0; i < nranks; i++) {
     if ((i != rank) && (comm->peerInfo[i].hostHash == comm->peerInfo[rank].hostHash) && (comm->peerInfo[i].busId == comm->peerInfo[rank].busId)) {

--- a/src/misc/socket.cc
+++ b/src/misc/socket.cc
@@ -4,13 +4,16 @@
  * See LICENSE.txt for license information
  ************************************************************************/
 
-#include "socket.h"
-#include "utils.h"
 #include <stdlib.h>
-
 #include <unistd.h>
 #include <ifaddrs.h>
 #include <net/if.h>
+#include <array>
+#include <cstring>
+#include <mutex>
+
+#include "socket.h"
+#include "utils.h"
 #include "param.h"
 #include "nccl_cvars.h"
 
@@ -56,7 +59,8 @@ static ncclResult_t socketProgressOpt(int op, struct ncclSocket* sock, void* ptr
     }
     if (bytes == -1) {
       if (errno != EINTR && errno != EWOULDBLOCK && errno != EAGAIN) {
-        WARN("socketProgressOpt: Call to recv from %s failed : %s", ncclSocketToString(&sock->addr, line), strerror(errno));
+        const std::string& hostname = socketIPv6ToHostname[ncclSocketToIPv6String(&sock->addr)];
+        WARN("socketProgressOpt: Call to recv from %s(%s) failed : %s", ncclSocketToString(&sock->addr, line), hostname.c_str(), strerror(errno));
         return ncclRemoteError;
       } else {
         bytes = 0;
@@ -75,8 +79,9 @@ static ncclResult_t socketProgress(int op, struct ncclSocket* sock, void* ptr, i
   int closed;
   NCCLCHECK(socketProgressOpt(op, sock, ptr, size, offset, 0 /*block*/, &closed));
   if (closed) {
+    const std::string& hostname = socketIPv6ToHostname[ncclSocketToIPv6String(&sock->addr)];
     char line[SOCKET_NAME_MAXLEN+1];
-    WARN("socketProgress: Connection closed by remote peer %s", ncclSocketToString(&sock->addr, line, 0));
+    WARN("socketProgress: Connection closed by remote peer %s(%s)", ncclSocketToString(&sock->addr, line, 0), hostname.c_str());
     return ncclRemoteError;
   }
   return ncclSuccess;
@@ -104,6 +109,14 @@ const char *ncclSocketToString(union ncclSocketAddress *addr, char *buf, const i
   (void) getnameinfo(saddr, sizeof(union ncclSocketAddress), host, NI_MAXHOST, service, NI_MAXSERV, flag);
   sprintf(buf, "%s<%s>", host, service);
   return buf;
+}
+
+std::string ncclSocketToIPv6String(union ncclSocketAddress *addr) {
+  struct sockaddr *saddr = &addr->sa;
+  char host[NI_MAXHOST], service[NI_MAXSERV];
+  int flag = NI_NUMERICSERV | NI_NUMERICHOST;
+  (void) getnameinfo(saddr, sizeof(union ncclSocketAddress), host, NI_MAXHOST, service, NI_MAXSERV, flag);
+  return {host};
 }
 
 static uint16_t socketToPort(union ncclSocketAddress *addr) {
@@ -177,6 +190,10 @@ static int findInterfaces(const char* prefixList, char* names, union ncclSocketA
       strncpy(names+found*maxIfNameSize, interface->ifa_name, maxIfNameSize);
       // Store the IP address
       int salen = (family == AF_INET) ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6);
+
+      char addrStr[1024];
+      ncclSocketToString((union ncclSocketAddress *)interface->ifa_addr, addrStr, 1024);
+      WARN("Found interface %s:%s", interface->ifa_name, addrStr);
       memcpy(addrs+found, interface->ifa_addr, salen);
       found++;
     }
@@ -263,7 +280,8 @@ int ncclFindInterfaceMatchSubnet(char* ifNames, union ncclSocketAddress* localAd
   }
 
   if (found == 0) {
-    WARN("Net : No interface found in the same subnet as remote address %s", ncclSocketToString(remoteAddr, line_a));
+    const std::string& hostname = socketIPv6ToHostname[ncclSocketToIPv6String(remoteAddr)];
+    WARN("Net : No interface found in the same subnet as remote address %s(%s)", ncclSocketToString(remoteAddr, line_a), hostname.c_str());
   }
   freeifaddrs(interfaces);
   return found;
@@ -473,6 +491,11 @@ static ncclResult_t socketFinalizeAccept(struct ncclSocket* sock) {
     } else {
       sock->state = ncclSocketStateReady;
     }
+    received = 0;
+    char hostname[kMaxHostNameLen + 1];
+    NCCLCHECK(socketWait(NCCL_SOCKET_RECV, sock, hostname, kMaxHostNameLen+1, &received));
+    std::unique_lock<std::mutex> lock{socketMapMutex};
+    socketIPv6ToHostname[ncclSocketToIPv6String(&sock->addr)] = std::string{hostname};
   }
   return ncclSuccess;
 }
@@ -507,7 +530,8 @@ static ncclResult_t socketStartConnect(struct ncclSocket* sock) {
   } else {
     char line[SOCKET_NAME_MAXLEN+1];
     sock->state = ncclSocketStateError;
-    WARN("socketStartConnect: Connect to %s failed : %s", ncclSocketToString(&sock->addr, line), strerror(errno));
+    const std::string& hostname = socketIPv6ToHostname[ncclSocketToIPv6String(&sock->addr)];
+    WARN("socketStartConnect: Connect to %s(%s) failed : %s", ncclSocketToString(&sock->addr, line), hostname.c_str(), strerror(errno));
     return ncclSystemError;
   }
 }
@@ -576,6 +600,10 @@ static ncclResult_t socketFinalizeConnect(struct ncclSocket* sock) {
   NCCLCHECK(socketWait(NCCL_SOCKET_SEND, sock, &sock->magic, sizeof(sock->magic), &sent));
   sent = 0;
   NCCLCHECK(socketWait(NCCL_SOCKET_SEND, sock, &sock->type, sizeof(sock->type), &sent));
+  sent = 0;
+  char hostname[kMaxHostNameLen + 1];
+  gethostname(hostname, kMaxHostNameLen + 1);
+  NCCLCHECK(socketWait(NCCL_SOCKET_SEND, sock, hostname, kMaxHostNameLen + 1, &sent));
   sock->state = ncclSocketStateReady;
   return ncclSuccess;
 }
@@ -737,8 +765,9 @@ ncclResult_t ncclSocketInit(struct ncclSocket* sock, union ncclSocketAddress* ad
     family = sock->addr.sa.sa_family;
     if (family != AF_INET && family != AF_INET6) {
       char line[SOCKET_NAME_MAXLEN+1];
-      WARN("ncclSocketInit: connecting to address %s with family %d is neither AF_INET(%d) nor AF_INET6(%d)",
-          ncclSocketToString(&sock->addr, line), family, AF_INET, AF_INET6);
+      const std::string& hostname = socketIPv6ToHostname[ncclSocketToIPv6String(&sock->addr)];
+      WARN("ncclSocketInit: connecting to address %s(%s) with family %d is neither AF_INET(%d) nor AF_INET6(%d)",
+          ncclSocketToString(&sock->addr, line), hostname.c_str(), family, AF_INET, AF_INET6);
       ret = ncclInternalError;
       goto fail;
     }

--- a/src/proxy.cc
+++ b/src/proxy.cc
@@ -873,6 +873,7 @@ static int setProxyThreadContext(struct ncclProxyState* proxyState) {
 
 void* ncclProxyProgress(void *proxyState_) {
   struct ncclProxyState* proxyState = (struct ncclProxyState*)proxyState_;
+  NCCL_NAMED_THREAD_START("Proxy");
   if (setProxyThreadContext(proxyState)) {
     INFO(NCCL_INIT, "[Proxy Progress] Created CUDA context on device %d", proxyState->cudaDev);
   } else if (cudaSetDevice(proxyState->cudaDev) != cudaSuccess) {
@@ -1446,6 +1447,7 @@ static bool proxyMatchOpType(int type) {
 }
 
 void* ncclProxyService(void* _args) {
+  NCCL_NAMED_THREAD_START("Service");
   nProxyComms++;
   struct ncclProxyState* proxyState =  (struct ncclProxyState*) _args;
   // if (CPU_COUNT(&comm->cpuAffinity)) sched_setaffinity(0, sizeof(cpu_set_t), &comm->cpuAffinity);

--- a/src/transport/net_socket.cc
+++ b/src/transport/net_socket.cc
@@ -506,9 +506,10 @@ ncclResult_t ncclNetSocketTest(void* request, int* done, int* size) {
       char line[SOCKET_NAME_MAXLEN+1];
       union ncclSocketAddress addr;
       ncclSocketGetAddr(r->ctrlSock, &addr);
-      WARN("NET/Socket : peer %s message truncated : receiving %d bytes instead of %d. If you believe your socket network is in healthy state, \
+      const std::string& hostname = socketIPv6ToHostname[ncclSocketToIPv6String(&addr)];
+      WARN("NET/Socket : peer %s(%s) message truncated : receiving %d bytes instead of %d. If you believe your socket network is in healthy state, \
           there may be a mismatch in collective sizes or environment settings (e.g. NCCL_PROTO, NCCL_ALGO) between ranks",
-          ncclSocketToString(&addr, line), data, r->size);
+          ncclSocketToString(&addr, line), hostname.c_str(), data, r->size);
       return ncclInvalidUsage;
     }
     r->size = data;

--- a/src/transport/net_socket.cc
+++ b/src/transport/net_socket.cc
@@ -224,6 +224,7 @@ void* persistentSocketThread(void *args_) {
   struct ncclNetSocketComm* comm = resource->comm;
   struct ncclNetSocketTaskQueue* myQueue = &resource->threadTaskQueue;
   int nSocksPerThread = comm->nSocks / comm->nThreads;
+  NCCL_NAMED_THREAD_START("PersistSocket");
   while (1) {
     int idle = 1;
     int mark = myQueue->next; // mark newest task seen


### PR DESCRIPTION
Summary: To improve readability of NCCL logs at troubleshooting, this patch adds host name for a lot of WARN logs.

Differential Revision: D55283669


