### PR TITLE
Fix a bug in NCCL 2.18 that causes async error not signaled

### DIFF
--- a/src/include/proxy.h
+++ b/src/include/proxy.h
@@ -7,6 +7,8 @@
 #ifndef NCCL_PROXY_H_
 #define NCCL_PROXY_H_
 
+#include <atomic>
+
 #include "devcomm.h"
 #include "info.h"
 #include "socket.h"
@@ -207,6 +209,7 @@ struct ncclProxyState {
   struct ncclSocket* listenSock;
   int stop;
   CUcontext cudaCtx;
+  std::atomic<ncclResult_t> asyncResult = ncclSuccess;
 
   // Used by main thread
   union ncclSocketAddress* peerAddresses;

--- a/src/init.cc
+++ b/src/init.cc
@@ -2374,6 +2374,9 @@ ncclResult_t ncclCommGetAsyncError(ncclComm_t comm, ncclResult_t *asyncError) {
   NCCLCHECK(PtrCheck(asyncError, "ncclGetAsyncError", "asyncError"));
 
   *asyncError = __atomic_load_n(&comm->asyncResult, __ATOMIC_ACQUIRE);
+  if (*asyncError == ncclSuccess && comm->proxyState) {
+    *asyncError = comm->proxyState->asyncResult;
+  }
   return ncclSuccess;
 }
 

--- a/src/proxy.cc
+++ b/src/proxy.cc
@@ -902,6 +902,7 @@ void* ncclProxyProgress(void *proxyState_) {
     int idle = 1;
     ncclResult_t ret = progressOps(proxyState, state, state->active, &idle);
     if (ret != ncclSuccess) {
+      proxyState->asyncResult = ret;
       INFO(NCCL_ALL,"%s:%d -> %d [Proxy Thread]", __FILE__, __LINE__, ret);
       return NULL;
     }
@@ -915,6 +916,7 @@ void* ncclProxyProgress(void *proxyState_) {
         ret = ncclProxyGetPostedOps(proxyState, &added);
       if (added) { TIME_STOP(3); } else { TIME_CANCEL(3); }
       if (ret != ncclSuccess) {
+        proxyState->asyncResult = ret;
         INFO(NCCL_ALL,"%s:%d -> %d [Proxy Thread]", __FILE__, __LINE__, ret);
       }
       if (added == 0) {

--- a/src/tests/CommAsyncError.cc
+++ b/src/tests/CommAsyncError.cc
@@ -1,0 +1,98 @@
+#include <stdio.h>
+#include "cuda_runtime.h"
+#include "nccl.h"
+#include "comm.h"
+#include "mpi.h"
+#include <gtest/gtest.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include "tests_common.cuh"
+
+class MPIEnvironment : public ::testing::Environment {
+ public:
+  void SetUp() override {
+    initializeMpi(0, NULL);
+    setenv("NCCL_DEBUG", "WARN", 0);
+    // Initialize CVAR so that we can overwrite global variable in each test
+    initEnv();
+  }
+
+  void TearDown() override {
+    finalizeMpi();
+  }
+  ~MPIEnvironment() override {}
+};
+
+class ProxyTraceTest : public ::testing::Test {
+ public:
+  ProxyTraceTest() = default;
+  void SetUp() override {
+    std::tie(this->localRank, this->globalRank, this->numRanks) = getMpiInfo();
+
+    CUDACHECK_TEST(cudaSetDevice(this->localRank));
+    CUDACHECK_TEST(cudaStreamCreate(&this->stream));
+    CUDACHECK_TEST(cudaMalloc(&sendBuf, count * sizeof(int)));
+    CUDACHECK_TEST(cudaMalloc(&recvBuf, count * sizeof(int)));
+  }
+
+  void TearDown() override {
+    CUDACHECK_TEST(cudaStreamDestroy(this->stream));
+    CUDACHECK_TEST(cudaFree(sendBuf));
+    CUDACHECK_TEST(cudaFree(recvBuf));
+  }
+
+  void runAllReduce(const int nColl, ncclComm_t comm) {
+    for (int i = 0; i < nColl; i++) {
+      NCCLCHECK_TEST(ncclAllReduce(
+          sendBuf, recvBuf, count, ncclInt, ncclSum, comm, stream));
+    }
+  }
+
+ protected:
+  int count{32*1024*1024};
+  int localRank{0};
+  int globalRank{0};
+  int numRanks{0};
+  int* sendBuf{nullptr};
+  int* recvBuf{nullptr};
+  cudaStream_t stream;
+};
+
+TEST_F(ProxyTraceTest, QueryHangSendRecv) {
+  int size = 32*1024*1024;
+
+  auto comm = createNcclComm(this->globalRank, this->numRanks, this->localRank);
+
+  if (comm->nNodes < 2) {
+    ncclCommDestroy(comm);
+    GTEST_SKIP() << "Skipping test since nNodes < 2";
+  }
+
+  runAllReduce(100, comm);
+
+  CUDACHECK_TEST(cudaStreamSynchronize(stream));
+
+  // Manually cause one rank to not be available.
+  // Since we are just checking the failure returned, how exactly it failed
+  // doesn't matter to us.
+  if (globalRank == 1) {
+    ncclCommAbort(comm);
+    sleep(20);
+  } else {
+    sleep(3);
+    runAllReduce(1, comm);
+    sleep(15);
+    ncclResult_t result;
+    NCCLCHECK_TEST(ncclCommGetAsyncError(comm, &result));
+    EXPECT_EQ(result, ncclRemoteError);
+    ncclCommAbort(comm);
+  }
+
+}
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new MPIEnvironment);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Summary:
Nvidia deleted the function call to report async error in NCCL 2.18.1 https://fburl.com/f0acqvmr, which results in async error never being reported. This causes IB timeout not being able to properly propagate to PyTorch and causing a lot of NCCL watchdog timeouts.
Fix the issue by mostly copying what Nvidia did in 2.19 (where they add it back)
facepalm

Differential Revision: D55515236


