### PR TITLE
Log CudaMalloc/CudaCalloc/ncclCudaCallocAsync calls

### DIFF
--- a/src/algorithms/AlgoManagerBase.cc
+++ b/src/algorithms/AlgoManagerBase.cc
@@ -46,6 +46,7 @@ AlgoManagerBase::AlgoManagerBase(ncclComm_t comm) : comm_(comm), memHandler_(com
   // 1) [r0, r1, ..., rN-1]
   // 2) [r0, r1, ..., rN-1]@block0, [r0, r1, ..., rN-1]@block1, ...@blockK-1
   // 3) [r0, r1, ..., rN-1]@block0, [r0, r1, ..., rN-1]@block1, ...@blockK-1
+  TRACE(NCCL_ALLOC, "Cuda Alloc Size %ld pointer (cudaMalloc)", (1 + 2 * maxBlocks_) * comm_->nRanks * sizeof(uintptr_t));
   CUDACHECKIGNORE(cudaMalloc(
       &threadedBarrierMbox_d_,
       ((1 + 2 * maxBlocks_) * comm_->nRanks) * sizeof(uintptr_t)));
@@ -56,6 +57,7 @@ AlgoManagerBase::AlgoManagerBase(ncclComm_t comm) : comm_(comm), memHandler_(com
 
   // For IPC, we can reuse the same mbox across barrier operations by
   // incrementing the barrierFlag.
+  TRACE(NCCL_ALLOC, "Cuda Alloc Size %ld pointer (cudaMalloc)", maxBlocks_ * comm_->nRanks * sizeof(uintptr_t));
   CUDACHECKIGNORE(cudaMalloc(
       &ipcBarrierMbox_d_,
       maxBlocks_ * comm_->nRanks * sizeof(uintptr_t)));
@@ -64,7 +66,9 @@ AlgoManagerBase::AlgoManagerBase(ncclComm_t comm) : comm_(comm), memHandler_(com
       0,
       maxBlocks_ * comm_->nRanks * sizeof(uintptr_t)));
 
+  TRACE(NCCL_ALLOC, "Cuda Alloc Size %ld pointer (cudaMalloc)", NCCL_DDA_TMPBUFF_SIZE);
   CUDACHECKIGNORE(cudaMalloc(&tmpbuff_d_, NCCL_DDA_TMPBUFF_SIZE));
+  TRACE(NCCL_ALLOC, "Cuda Alloc Size %ld pointer (cudaMalloc)", sizeof(DdaDeviceState) * comm_->nRanks);
   CUDACHECKIGNORE(
       cudaMalloc(&devStates_d_, sizeof(DdaDeviceState) * comm_->nRanks));
 

--- a/src/algorithms/DdaMemHandler.cc
+++ b/src/algorithms/DdaMemHandler.cc
@@ -45,7 +45,9 @@ ncclResult_t DdaMemHandler::exchangeMemHandles() {
   std::vector<ExchangedHandle> recvHandles(kNumRecvHandle);
   ExchangedHandle* sendBuff_d{nullptr};
   ExchangedHandle* recvBuff_d{nullptr};
+  TRACE(NCCL_ALLOC, "Cuda Alloc Size %ld pointer (cudaMalloc)", kSendSize);
   CUDACHECK(cudaMalloc(&sendBuff_d, kSendSize));
+  TRACE(NCCL_ALLOC, "Cuda Alloc Size %ld pointer (cudaMalloc)", kRecvSize);
   CUDACHECK(cudaMalloc(&recvBuff_d, kRecvSize));
 
   // fill up sendbuffs

--- a/src/ctran/algos/CtranAlgo.cc
+++ b/src/ctran/algos/CtranAlgo.cc
@@ -110,6 +110,7 @@ ncclResult_t CtranAlgo::initDevState() {
   }
 
   // Copy contents to device
+  TRACE(NCCL_ALLOC, "Cuda Alloc Size %ld pointer (cudaMalloc)", sizeof(CtranAlgoDeviceState));
   CUDACHECK(cudaMalloc(&this->devState_d, sizeof(CtranAlgoDeviceState)));
   CUDACHECK(cudaMemcpy(
       this->devState_d,
@@ -133,6 +134,7 @@ CtranAlgo::SharedResource::SharedResource(ncclComm* comm) {
       (sizeof(CtranAlgoDeviceBufState) + NCCL_CTRAN_SHARED_DEVBUF_SIZE) *
       (this->comm_->localRanks - 1);
 
+  TRACE(NCCL_ALLOC, "Cuda Alloc Size %ld pointer (cudaMalloc)", shmSize);
   CUDACHECKTHROW(cudaMalloc(&this->devShmPtr_, shmSize));
   CUDACHECKTHROW(
       cudaIpcGetMemHandle(&handles[this->comm_->localRank], this->devShmPtr_));

--- a/src/include/alloc.h
+++ b/src/include/alloc.h
@@ -158,7 +158,7 @@ ncclResult_t ncclCudaMallocDebug(T** ptr, size_t nelem, const char *filefunc, in
 finish:
   CUDACHECK(cudaThreadExchangeStreamCaptureMode(&mode));
   if (*ptr == nullptr) WARN("Failed to CUDA malloc %ld bytes", nelem*sizeof(T));
-  INFO(NCCL_ALLOC, "%s:%d Cuda Alloc Size %ld pointer %p", filefunc, line, nelem*sizeof(T), *ptr);
+  INFO(NCCL_ALLOC, "%s:%d Cuda Alloc Size %ld pointer %p (Malloc)", filefunc, line, nelem*sizeof(T), *ptr);
   return result;
 }
 #define ncclCudaMalloc(...) ncclCudaMallocDebug(__VA_ARGS__, __FILE__, __LINE__)
@@ -183,7 +183,7 @@ ncclResult_t ncclCudaCallocDebug(T** ptr, size_t nelem, const char *filefunc, in
 finish:
   CUDACHECK(cudaThreadExchangeStreamCaptureMode(&mode));
   if (*ptr == nullptr) WARN("Failed to CUDA calloc %ld bytes", nelem*sizeof(T));
-  INFO(NCCL_ALLOC, "%s:%d Cuda Alloc Size %ld pointer %p", filefunc, line, nelem*sizeof(T), *ptr);
+  INFO(NCCL_ALLOC, "%s:%d Cuda Alloc Size %ld pointer %p (Calloc)", filefunc, line, nelem*sizeof(T), *ptr);
   return result;
 }
 #define ncclCudaCalloc(...) ncclCudaCallocDebug(__VA_ARGS__, __FILE__, __LINE__)
@@ -203,7 +203,7 @@ ncclResult_t ncclCudaCallocAsyncDebug(T** ptr, size_t nelem, cudaStream_t stream
 finish:
   CUDACHECK(cudaThreadExchangeStreamCaptureMode(&mode));
   if (*ptr == nullptr) WARN("Failed to CUDA calloc async %ld bytes", nelem*sizeof(T));
-  INFO(NCCL_ALLOC, "%s:%d Cuda Alloc Size %ld pointer %p", filefunc, line, nelem*sizeof(T), *ptr);
+  INFO(NCCL_ALLOC, "%s:%d Cuda Alloc Size %ld pointer %p (CallocAsync)", filefunc, line, nelem*sizeof(T), *ptr);
   return result;
 }
 #define ncclCudaCallocAsync(...) ncclCudaCallocAsyncDebug(__VA_ARGS__, __FILE__, __LINE__)

--- a/src/transport.cc
+++ b/src/transport.cc
@@ -40,7 +40,9 @@ static ncclResult_t selectTransport(struct ncclComm* comm, struct ncclTopoGraph*
     struct ncclTransportComm* transportComm = type == 1 ? &transport->send : &transport->recv;
     int ret = 0;
     NCCLCHECK(transport->canConnect(&ret, comm->topo, graph, myInfo, peerInfo));
+    TRACE(NCCL_INIT, "checking Channel %02d : %d -> %d transport: %s", channelId, myInfo->rank, peerInfo->rank, transport->name);
     if (ret) {
+      TRACE(NCCL_INIT, "can connect, Channel %02d : %d -> %d transport: %s", channelId, myInfo->rank, peerInfo->rank, transport->name);
       connector->transportComm = transportComm;
       NCCLCHECK(transportComm->setup(comm, graph, myInfo, peerInfo, connect, connector, channelId, connIndex));
       if (transportType) *transportType = t;

--- a/src/transport/coll_net.cc
+++ b/src/transport/coll_net.cc
@@ -157,6 +157,7 @@ static ncclResult_t sendSetup(struct ncclComm* comm, struct ncclTopoGraph* graph
   NCCLCHECK(ncclProxyConnect(comm, TRANSPORT_COLLNET, 1, tpProxyRank, &send->proxyConn));
   ncclAtomicRefCountIncrement(&comm->collNetSharedRes->refCount);
   req.collNet = comm->collNetSharedRes;
+  TRACE(NCCL_ALLOC, "calling ncclProxyCallBlocking size: %i, type: %i for rank: %i",  *((int*)&req), ncclProxyMsgSetup, tpProxyRank);
   NCCLCHECK(ncclProxyCallBlocking(comm, &send->proxyConn, ncclProxyMsgSetup, &req, sizeof(req), NULL, 0));
 
   INFO(NCCL_INIT|NCCL_NET,"CollNet %02d/%1d : %d [send] via COLLNET/%s/%d%s", channelId, connIndex, myInfo->rank, collNetName(comm), req.netDev,
@@ -180,6 +181,7 @@ static ncclResult_t recvSetup(struct ncclComm* comm, struct ncclTopoGraph* graph
   struct collNetRecvConnectInfo* info = (struct collNetRecvConnectInfo*) connectInfo;
   ncclAtomicRefCountIncrement(&comm->collNetSharedRes->refCount);
   req.collNet = comm->collNetSharedRes;
+  TRACE(NCCL_ALLOC, "calling ncclProxyCallBlocking size: %i, type: %i for rank: %i",  *((int*)&req), ncclProxyMsgSetup, tpProxyRank);
   NCCLCHECK(ncclProxyCallBlocking(comm, &recv->proxyConn, ncclProxyMsgSetup, &req, sizeof(req), &info->collNetHandle, sizeof(collNetHandle_t)));
 
   INFO(NCCL_INIT|NCCL_NET,"CollNet %02d/%1d : %d [receive] via COLLNET/%s/%d%s", channelId, connIndex, myInfo->rank, collNetName(comm), req.netDev,

--- a/src/window.cc
+++ b/src/window.cc
@@ -61,6 +61,7 @@ ncclResult_t ncclWinAllocShared(size_t size, ncclComm_t comm, ncclWin_t* win) {
 
   // TODO: use memory pool
   void *addr;
+  TRACE(NCCL_ALLOC, "Cuda Alloc Size %ld pointer (cudaMalloc)", size);
   CUDACHECK(cudaMalloc(&addr, size));
 
   // No need to open IPC for sinlge-process communicator


### PR DESCRIPTION
Summary:
Add a few logs for memory profiling purposes:
1. Separate 3 alloc.h GPU memory allocation calls explicitly (Malloc/Calloc/CallocAsync)
2. Manually logged CudaMalloc calls (AlgoManagerBase.cc, DdaMemHandler.cc, CtranAlgo.cc, window.cc)
3. Log ncclCommSplit and ncclCommInitRank call in init.cc
4. Log ncclProxyCallBlocking calls in init.cc
5. Log ncclP2pAllocateShareableBuffer direct calls in p2p.cc
6. Log ncclProxyCallBlocking calls in p2p.cc
7. Log ncclProxyCallAsync calls for ncclProxyMsgSetup/ncclProxyMsgConnect/ncclProxyMsgSharedInit event types in proxy.cc
8. Log transport types in selectTransport in transport.cc
9. Log sendSetup/recvSetup call in coll_net.cc
10. Log sharedBuffersInit calls in net.cc

Differential Revision: D55086879


